### PR TITLE
[WIP] Support of NUnit3

### DIFF
--- a/src/FsUnit.NUnit/FsUnit.Extra.fs
+++ b/src/FsUnit.NUnit/FsUnit.Extra.fs
@@ -5,13 +5,14 @@ open NUnit.Framework.Constraints
 
 type ChoiceConstraint(n) =
   inherit Constraint() with
-    override this.WriteDescriptionTo(writer: MessageWriter): unit =
-      writer.WritePredicate("is choice")
-      writer.WriteExpectedValue(sprintf "%d" n)
-    override this.Matches(actual: obj) =
-      match actual with
+    override __.Description with get () = sprintf "is choice %d" n
+    
+    override this.ApplyTo(actual : 'TActual) : ConstraintResult =        
+        match box actual with // Forced to box to match C# constraint on 'TActual
         | null -> raise (new ArgumentException("The actual value must be a non-null choice"))
-        | o -> (new CustomMatchers.ChoiceDiscriminator(n)).check(o)
+        | o    -> let actualType = actual.GetType()
+                  let isSuccess = (new CustomMatchers.ChoiceDiscriminator(n)).check(o)
+                  ConstraintResult(this, actualType, isSuccess) 
 
 [<AutoOpen>]
 module TopLevelOperatorsExtra =

--- a/src/FsUnit.NUnit/FsUnit.fs
+++ b/src/FsUnit.NUnit/FsUnit.fs
@@ -9,13 +9,7 @@ open NUnit.Framework.Constraints
 /// F#-friendly formatting for otherwise the same equals behavior (%A instead of .ToString())
 type EqualsConstraint(x:obj) =
   inherit EqualConstraint(x) with
-    override this.WriteActualValueTo(writer: MessageWriter): unit =
-      writer.WriteActualValue(sprintf "%A" this.actual)
-    override this.WriteDescriptionTo(writer: MessageWriter): unit =
-      writer.WritePredicate("equals")
-      writer.WriteExpectedValue(sprintf "%A" x)
-    override this.WriteMessage(writer: MessageWriter): unit =
-      writer.WriteMessageLine(sprintf "Expected: %A, but was %A" x this.actual)
+    override __.Description with get () = sprintf "equals %A" x
 
 //
 [<AutoOpen>]


### PR DESCRIPTION
Based on NUnit3 source code I propose the following migration of the
custom constraints.
- We should add tests to prove the WriteDescriptionTo method migration
  is doing what is intended.
- The F#-friendly formatting has been partially merged. We need to
  decide if the EqualConstraintResult class is good enough or if we
  inherit it and make it F#-friendly.
