### PR TITLE
Fix nunit with .net core

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -127,11 +127,7 @@ Target "Build" (fun _ ->
 // Run the unit tests using test runner
 
 Target "NUnit" (fun _ ->
-    !! "tests/**/bin/Release/**/*NUnit.Test.dll"
-    |> NUnit3 (fun p ->
-        { p with
-            Labels = LabelsLevel.All
-            TimeOut = TimeSpan.FromMinutes 20.})
+    DotNetCli.RunCommand (fun c -> { c with WorkingDir = "tests/FsUnit.NUnit.Test" }) "run"
 )
 
 Target "xUnit" (fun _ ->

--- a/tests/FsUnit.NUnit.Test/FsUnit.NUnit.Test.fsproj
+++ b/tests/FsUnit.NUnit.Test/FsUnit.NUnit.Test.fsproj
@@ -1,7 +1,6 @@
 <Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk" >
   <PropertyGroup>
     <TargetFramework>netcoreapp1.0</TargetFramework>
-    <Version>2.4.0-alpha</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="init.fs" />

--- a/tests/FsUnit.NUnit.Test/FsUnit.NUnit.Test.fsproj
+++ b/tests/FsUnit.NUnit.Test/FsUnit.NUnit.Test.fsproj
@@ -1,5 +1,6 @@
 <Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk" >
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
@@ -40,12 +41,14 @@
     <Compile Include="typed.shouldFailTests.fs" />
     <Compile Include="typed.haveLengthTests.fs" />
     <Compile Include="typed.shouldContainText.fs" />
+    <Compile Include="main.fs" />
     <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.1.*" />
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.6.0" />
+    <PackageReference Include="NUnitLite" Version="3.6.0" />
     <PackageReference Include="System.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
     <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />

--- a/tests/FsUnit.NUnit.Test/FsUnit.NUnit.Test.fsproj
+++ b/tests/FsUnit.NUnit.Test/FsUnit.NUnit.Test.fsproj
@@ -49,10 +49,6 @@
     <PackageReference Include="System.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
     <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
-    <ProjectReference Include="..\..\src\FsUnit.NUnit\FsUnit.NUnit.fsproj">
-      <Name>FsUnit.NUnit</Name>
-      <Project>{3890dc0f-5225-4adf-9b9e-f6a482046a9e}</Project>
-      <Private>True</Private>
-    </ProjectReference>
+    <ProjectReference Include="..\..\src\FsUnit.NUnit\FsUnit.NUnit.fsproj" />
   </ItemGroup>
 </Project>

--- a/tests/FsUnit.NUnit.Test/main.fs
+++ b/tests/FsUnit.NUnit.Test/main.fs
@@ -1,0 +1,13 @@
+namespace FsUnit.Test
+
+open NUnit.Framework
+open NUnitLite
+open System.Reflection
+
+type T = { Dummy : string }
+
+module Program =
+
+    [<EntryPoint>]
+    let main args =
+        (new AutoRun(typeof<T>.GetTypeInfo().Assembly)).Execute(args)


### PR DESCRIPTION
use nunitlite for .netcore testing

nunit doesnt support yet `dotnet test` and netstandard lib (ref nunit/nunit3-vs-adapter#297 )

Is possible to use nunit lite, ref https://github.com/nunit/docs/wiki/NUnitLite-Runner

The test lib become a normal console app, and the nunit runner is embeeded (nunitlite.dll), and autostarted at main

added some cleanup to fsproj and changed fake script