### PR TITLE
Removes (first) condition for target frameworks in project files.

### DIFF
--- a/src/FsUnit.MsTestUnit/FsUnit.MsTest.fsproj
+++ b/src/FsUnit.MsTestUnit/FsUnit.MsTest.fsproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+  <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">

--- a/src/FsUnit.NUnit/FsUnit.NUnit.fsproj
+++ b/src/FsUnit.NUnit/FsUnit.NUnit.fsproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+  <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">

--- a/src/FsUnit.Xunit/FsUnit.Xunit.fsproj
+++ b/src/FsUnit.Xunit/FsUnit.Xunit.fsproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+  <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">


### PR DESCRIPTION
Let's try to fix this build!

What happend there?
I removed the first of the two conditionals wrapping the target frameworks. Paket restore seems to have troubles with the conditionals and therefore did not find any target frameworks -> did not restore anything -> build fails. (Btw. that this is Pakets fault is not any more than my mere guess - no actual investigation so far).
What I leverage here is the fact, that MSBuild takes multiple property declarations as overrides. Event `<TargetFramework>` overrides `<TargetFrameworks>` - which is cool 😄 

This made the build, at least for me locally, to succeed. I played around with inverting the condition to make sure that works as well...